### PR TITLE
bugfix: missing blank in xml and urllib import for python 2

### DIFF
--- a/pyviera/__init__.py
+++ b/pyviera/__init__.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     # Python 2
     from urllib2 import urlopen, urlparse, Request
-    from urlparse import urljoin
+    from urlparse import urljoin, urlparse
 
 LOGGER = logging.getLogger("pyviera")
 
@@ -199,7 +199,7 @@ class Viera(object):
 
             soap_body = (
                 '<?xml version="1.0"?>'
-                '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope"'
+                '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope" '
                 'SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">'
                 '<SOAP-ENV:Body>'
                 '<m:{name} xmlns:m="{service_type}">'


### PR DESCRIPTION
code didnt work for python 2 - urlparse was still a module at the point it was used. after fixing it, packets were still incorret - tv resopnded with 400 bad request. missing blank fixed that